### PR TITLE
Fix for build on OS X with non-default locale.

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -2,6 +2,8 @@
 
 # Breaks on Darwin w/o this
 export LANG=C
+export LC_CTYPE=C
+export LC_ALL=C
 
 prep()
 {


### PR DESCRIPTION
See http://bugs.mysql.com/bug.php?id=66811 for details of the upstream MySQL
bug and DM-2372 for the (identical) fix applied to LSST's mysql package.
